### PR TITLE
develop fix toaster.module.d.ts ok restrictions ng build--aot

### DIFF
--- a/src/lib/toaster/toaster.module.d.ts
+++ b/src/lib/toaster/toaster.module.d.ts
@@ -1,2 +1,5 @@
+import { NgModule } from '@angular/core';
+@NgModule({
+})
 export declare class ToasterModule {
 }


### PR DESCRIPTION
This fix is needed when we do ng build --aot using buildOptimizer @angular-devkit/build-optimizer.
Adding the import an annotation at toaster.module.d.ts we do not have any errors at build.
Hope this will be usefull and I want to apreciate all the afford you made with this ngx-toaster, really good component for my Angular 5 app.
Thank you. 
David Campo.